### PR TITLE
Filter item by itemId

### DIFF
--- a/MarketService.Tests/MarketControllerTest.cs
+++ b/MarketService.Tests/MarketControllerTest.cs
@@ -65,7 +65,7 @@ public class MarketControllerTest
             SizeLimit = null,
         });
         var controller = new MarketController(_logger, _context, cache);
-        var response = await controller.GetItemProducts((int) ItemSubType.Armor, null, null, null, null, Array.Empty<int>(), false);
+        var response = await controller.GetItemProducts((int) ItemSubType.Armor, null, null, null, null, Array.Empty<int>(), Array.Empty<int>(), false);
         var result = Assert.Single(response.ItemProducts);
         Assert.IsType<ItemProductResponseModel>(result);
         Assert.Equal(product.ProductId, result.ProductId);
@@ -227,14 +227,14 @@ public class MarketControllerTest
         var controller = new MarketController(_logger, _context, cache);
         foreach (var stat in new [] {"atk", "ATK", "HP", "hp", "Hp", "Atk", null })
         {
-            var response = await controller.GetItemProducts((int) ItemSubType.Armor, null, null, null, stat, Array.Empty<int>(), false);
+            var response = await controller.GetItemProducts((int) ItemSubType.Armor, null, null, null, stat, Array.Empty<int>(), Array.Empty<int>(), false);
             var result = Assert.Single(response.ItemProducts);
             Assert.IsType<ItemProductResponseModel>(result);
             Assert.Equal(product.ProductId, result.ProductId);
             Assert.Equal(2, result.Quantity);
             Assert.Equal(3, result.Price);
         }
-        var response2 = await controller.GetItemProducts((int) ItemSubType.Armor, null, null, null, "DEF", Array.Empty<int>(), false);
+        var response2 = await controller.GetItemProducts((int) ItemSubType.Armor, null, null, null, "DEF", Array.Empty<int>(), Array.Empty<int>(), false);
         Assert.Empty(response2.ItemProducts);
         await _context.Database.EnsureDeletedAsync();
     }

--- a/MarketService/Controllers/MarketController.cs
+++ b/MarketService/Controllers/MarketController.cs
@@ -28,7 +28,8 @@ public class MarketController : ControllerBase
     }
 
     [HttpGet("products/items/{type}")]
-    public async Task<MarketProductResponse> GetItemProducts(int type, int? limit, int? offset, string? order, string? stat, [FromQuery] int[] iconIds, bool isCustom)
+    public async Task<MarketProductResponse> GetItemProducts(int type, int? limit, int? offset, string? order,
+        string? stat, [FromQuery] int[] itemIds, [FromQuery] int[] iconIds, bool isCustom)
     {
         var itemSubType = (ItemSubType) type;
         var queryOffset = offset ?? 0;

--- a/MarketService/Controllers/MarketController.cs
+++ b/MarketService/Controllers/MarketController.cs
@@ -47,6 +47,18 @@ public class MarketController : ControllerBase
                 .Take(queryLimit));
     }
 
+    /// <summary>
+    /// Query and get filtered item list from market service.
+    /// </summary>
+    /// <param name="itemSubType">Item subtype to query.</param>
+    /// <param name="queryLimit">Result count limit.</param>
+    /// <param name="queryOffset">Offset to find from.</param>
+    /// <param name="sort">Type of sorting result.</param>
+    /// <param name="statType">Target stat type to query.</param>
+    /// <param name="itemIds">Item IDs to filter. This will be ignored when `iconIds` comes in.</param>
+    /// <param name="iconIds">Icon IDs to filter. This only works for equipment. This will be solely used when both IconIds and ItemIds are incoming.</param>
+    /// <param name="isCustom">Flag to find from custom craft.</param>
+    /// <returns></returns>
     private async Task<List<ItemProductModel>> Get(ItemSubType itemSubType, int queryLimit, int queryOffset,
         string sort, StatType statType, int[] itemIds, int[] iconIds, bool isCustom)
     {
@@ -69,6 +81,7 @@ public class MarketController : ControllerBase
             query = query.Where(p => p.Stats.Any(s => s.Type == statType));
         }
 
+        // Use iconIds when present. Ignore itemIds in this case.
         if (iconIds.Any())
         {
             query = query.Where(p => iconIds.Contains(p.IconId));


### PR DESCRIPTION
- Take both itemIds and iconIds as param.
- Use iconIds first and use itemIds when no iconIds provided.
- Create cache key by iconIds and itemIds.

---
This PR resolves https://github.com/planetarium/NineChronicles/issues/6364